### PR TITLE
[Bug] Remove debug console.log statements

### DIFF
--- a/src/WordCollectorGame.js
+++ b/src/WordCollectorGame.js
@@ -129,7 +129,6 @@ const WordCollectorGame = () => {
     cancelAnimationFrame(requestRef.current);
     
     // The elapsed time is already tracked by our timer, no need to recalculate
-    console.log("Game over - elapsed time:", elapsedTime, "formatted as:", formatTime(elapsedTime));
   };
   
   // Save high score with player name
@@ -144,14 +143,6 @@ const WordCollectorGame = () => {
     }]
       .sort((a, b) => b.time - a.time) // Sort by longest time (descending)
       .slice(0, 5);
-    
-    // Log for debugging
-    console.log("Saving high score:", { 
-      name, 
-      time: elapsedTime, 
-      formattedTime: formatTime(elapsedTime),
-      points: Math.floor(score)
-    });
     
     setHighScores(newHighScores);
     setShowNameInput(false);


### PR DESCRIPTION
## Summary
- Removes two `console.log` calls left over from debugging in `WordCollectorGame.js`
- One logged elapsed time on game-over, the other logged high score details on save
- These expose internal game state in browser DevTools and add noise in production

## Test plan
- [ ] Start a game and let it end — no console output should appear
- [ ] Submit a high score — no console output should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)