### PR TITLE
[Bug] Remove unused wordlist-js dependency and fix package.json syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "word-collector",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://watts4.github.io/wcg",
   "dependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
@@ -11,15 +12,14 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4",
-    "wordlist-js": "^2.0.0"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-	"predeploy": "npm run build",
+    "predeploy": "npm run build",
     "deploy": "gh-pages -d build"
   },
   "eslintConfig": {
@@ -46,7 +46,4 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^4.0.14"
   }
-  
-  "homepage": "https://watts4.github.io/wcg",
-
 }


### PR DESCRIPTION
## Summary
- Removes `wordlist-js` from `dependencies` — it is declared but never imported anywhere in the source; only `an-array-of-english-words` is actually used
- Fixes a missing comma after the `devDependencies` closing brace that made `package.json` technically invalid JSON (strict parsers would fail)
- Also moves `homepage` to a more conventional position near the top of the file

## Test plan
- [ ] `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` passes
- [ ] `npm install` completes without errors
- [ ] `npm run build` succeeds
- [ ] Word validation still works in the game (uses `an-array-of-english-words`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)