### PR TITLE
fix: use literal difficulty=1 in startGame generation interval

### DIFF
--- a/src/WordCollectorGame.jsx
+++ b/src/WordCollectorGame.jsx
@@ -220,7 +220,7 @@ const WordCollectorGame = () => {
 
     generationLoopRef.current = setInterval(() => {
       generateNewElementRef.current();
-    }, 1200 - difficulty * 150);
+    }, 1200 - 1 * 150); // difficulty resets to 1; use literal to avoid stale closure
   };
 
   // Save high score with player name


### PR DESCRIPTION
## Summary
- `startGame()` calls `setDifficulty(1)` but React state updates are async — the `setInterval` call immediately after captured the **stale** `difficulty` value from the previous game (up to 10), making the letter generation interval far too short on "Play Again"
- Fix uses the literal `1050`ms (= `1200 - 1 * 150`) so the initial generation rate always matches the freshly-reset difficulty of 1

## Test plan
- [ ] Start a new game, play until difficulty increases significantly
- [ ] Let the game end, then click "Play Again"
- [ ] Confirm letters start falling at the same relaxed pace as the very first game, not the fast pace from when the previous game ended

🤖 Generated with [Claude Code](https://claude.com/claude-code)