### PR TITLE
chore: npm audit fix for postcss XSS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1996,9 +1996,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -2014,8 +2014,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
- Bumps `postcss` from 8.5.3 to a patched version (>=8.5.10) to resolve [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (moderate XSS via unescaped `</style>` in stringify output).
- Dev-only build dependency; does not affect the deployed bundle.
- `npm audit` now reports 0 vulnerabilities.

## Test plan
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)